### PR TITLE
fix add_observation - add missing self.

### DIFF
--- a/dcejson_exporter.py
+++ b/dcejson_exporter.py
@@ -292,7 +292,7 @@ class MessageProvenance: # Recorded history of a particular message. Sequence of
         assert observation.message_id == self.message_id
         # If we now have two deletion observations, just keep the earlier one
         if observation.dmo is None and self.observations[-1].dmo is None:
-            observations[-1] = min(observation, observations[-1])
+            self.observations[-1] = min(observation, self.observations[-1])
         self.observations.append(observation)
         self.observations.sort()
     """ Returns (author id, author username) if we've observed it, otherwise (None, None). """


### PR DESCRIPTION
fix missing `self.`

Fixes this stack traceback:
```
>py dcejson_exporter.py

 🧿 Initializing export 🧿

Analyzing REST traffic.
Analyzing websocket traffic.
Traceback (most recent call last):
  File "C:\_\programming\discordless\dcejson_exporter.py", line 437, in <module>
    observe_dmo(seen_timestamp, None, event_name, int(event["channel_id"]), int(event["id"]))
  File "C:\_\programming\discordless\dcejson_exporter.py", line 375, in observe_dmo
    channel_messages[channel_id][message_id].add_observation(observation)
  File "C:\_\programming\discordless\dcejson_exporter.py", line 295, in add_observation
    observations[-1] = min(observation, observations[-1])
NameError: name 'observations' is not defined. Did you mean: 'observation'?
```