### PR TITLE
Improve image handling in html exporter

### DIFF
--- a/html_exporter.py
+++ b/html_exporter.py
@@ -300,7 +300,7 @@ def reasonable_filename(filename: str) -> str:
     if not (MIN_LEN < len(filename) < MAX_LEN):
         unique_suffix = hex(unique_id_counter)[2:]
         unique_id_counter += 1
-        filename = filename[:MAX_LEN-len(unique_suffix)]+unique_suffix
+        filename = unique_suffix + filename[-(MAX_LEN-len(unique_suffix)):]
 
     return filename
 

--- a/html_exporter.py
+++ b/html_exporter.py
@@ -260,8 +260,47 @@ print("Collected {} messages and {} attachments from {} channels.".format(
     len(channel_messages)
 ))
 
-def reasonable_filename(filename):
-    return "".join(c if c.isalnum() else "_" for c in filename).rstrip()[:80]#[:255]
+unique_id_counter = 0
+"""
+Sanitizes a file or directory name
+
+This function shall do the following to the input:
+- alphanumeric characters
+- underscores and dots
+- no two or more dots in a series
+- invalid characters shall be replaced with a underscore
+- too long filenames shall be shortened
+- if a filename is shortened, a unique suffix is added to ensure uniqueness
+- if a filename is too short, add a unique suffix
+"""
+def reasonable_filename(filename: str) -> str:
+    global unique_id_counter
+
+    ALLOWED_CHARS = ["_", "."]
+    MAX_LEN = 80
+    MIN_LEN = 3
+
+    last_c = ""
+    valid = []
+    for c in filename:
+        if not c.isalnum() and c not in ALLOWED_CHARS:
+            c = "_"
+
+        if last_c == "." and c == ".":
+            continue  # we can skip updating last_c since last_c already equals c
+
+        valid.append(c)
+        last_c = c
+
+    filename = "".join(valid)
+
+    # ensure the length is okay. Otherwise, shorten it if required and add a unique suffix
+    if not (MIN_LEN < len(filename) < MAX_LEN):
+        unique_suffix = hex(unique_id_counter)[2:]
+        unique_id_counter += 1
+        filename = filename[:MAX_LEN-len(unique_suffix)]+unique_suffix
+
+    return filename
 
 
 if not DRY_RUN:

--- a/html_exporter.py
+++ b/html_exporter.py
@@ -14,6 +14,8 @@ import json
 import time
 import datetime
 import argparse
+
+import filetype
 from dateutil import parser
 from shutil import copyfile
 from parse_gateway import parse_gateway
@@ -422,13 +424,22 @@ if not DRY_RUN:
                     for attachment in dmo["attachments"]:
                         attachment_id = attachment_url_to_id(attachment["proxy_url"])
                         if attachment_id in all_attachments:
+                            is_image = any(attachment_id.lower().endswith(ext) for ext in (".png",".jpg",".jpeg",".gif",".bmp",".webp"))
+
                             if attachment_id not in chatlog_attachments:
-                                chatlog_attachment_path = os.path.join(chatlog_attachments_path, reasonable_filename(attachment_id))
+                                # discord sometimes converts the image format. Check what kind of image it really is and add the correct suffix
+                                filename = attachment_id
+                                if is_image:
+                                    extension = filetype.guess_extension(all_attachments[attachment_id])
+                                    if extension is not None:
+                                        filename = f"{filename}.{extension}"
+
+                                chatlog_attachment_path = os.path.join(chatlog_attachments_path, reasonable_filename(filename))
                                 chatlog_attachment_rel_path = os.path.relpath(chatlog_attachment_path, chatlog_path) # used for img src in chatlog.html
                                 copyfile(all_attachments[attachment_id], chatlog_attachment_path) # Make copy of the attachment for the chatlog
                                 chatlog_attachments.add(attachment_id)
                             # todo: support videos
-                            if any(attachment_id.lower().endswith(ext) for ext in (".png",".jpg",".jpeg",".gif",".bmp",".webp")):
+                            if is_image:
                                 edition["images"].append(chatlog_attachment_rel_path)
                             else:
                                 edition["attachment_links"].append(chatlog_attachment_rel_path)

--- a/html_exporter.py
+++ b/html_exporter.py
@@ -384,7 +384,7 @@ if not DRY_RUN:
                         attachment_id = attachment_url_to_id(attachment["proxy_url"])
                         if attachment_id in all_attachments:
                             if attachment_id not in chatlog_attachments:
-                                chatlog_attachment_path = os.path.join(chatlog_attachments_path, attachment_id) # todo: pick better file name
+                                chatlog_attachment_path = os.path.join(chatlog_attachments_path, reasonable_filename(attachment_id))
                                 chatlog_attachment_rel_path = os.path.relpath(chatlog_attachment_path, chatlog_path) # used for img src in chatlog.html
                                 copyfile(all_attachments[attachment_id], chatlog_attachment_path) # Make copy of the attachment for the chatlog
                                 chatlog_attachments.add(attachment_id)

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Here are example commands you can use on Ubuntu. Assumes you use Python 3.9, but
 - Update pip: `python3.9 -m pip install --upgrade pip`
 - Install mitmproxy: download the binaries from [mitmproxy.org](https://mitmproxy.org/)
 - [Install mitmproxy's certificate](https://docs.mitmproxy.org/stable/concepts-certificates/#quick-setup) on every device with a Discord client that you want to archive with. (Sometimes you also have to install it on the browser level.)
-- Install erlpack: `python3.9 -m pip install erlpack`
+- Install erlpack: `python3.9 -m pip install erlpack filetype`
 
 ## erlpack installation issue workaround
 
@@ -42,7 +42,7 @@ pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
 Mostly the same as the Debian-based Linux setup.
 
 - Install Python 3.9+
-- Install erlpack: `pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
+- Install erlpack: `pip install filetype git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
 - [Install mitmproxy](https://docs.mitmproxy.org/stable/overview-installation/#macos): `brew install mitmproxy`
 - Run mitmproxy at least once to generate its certificate: `mitmproxy`
 - [Install mitmproxy's certificate](https://docs.mitmproxy.org/stable/concepts-certificates/#quick-setup): `sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem`
@@ -66,7 +66,7 @@ Update pip and install `erlpack` and `python-dateutil` dependencies:
 ```
 py -m pip install --upgrade pip
 py -m pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack
-py -m pip install python-dateutil
+py -m pip install python-dateutil filetype
 ```
 
 Install mitmproxy from [official site](https://mitmproxy.org/). Mitmproxy installer for windows should automatically add `mitmproxy`, `mitmdump` and `mitmweb` to path. Close all opened command prompts to update PATH variable.

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Here are example commands you can use on Ubuntu. Assumes you use Python 3.9, but
 - Update pip: `python3.9 -m pip install --upgrade pip`
 - Install mitmproxy: download the binaries from [mitmproxy.org](https://mitmproxy.org/)
 - [Install mitmproxy's certificate](https://docs.mitmproxy.org/stable/concepts-certificates/#quick-setup) on every device with a Discord client that you want to archive with. (Sometimes you also have to install it on the browser level.)
-- Install erlpack: `python3.9 -m pip install erlpack filetype`
+- Install filetype and erlpack: `python3.9 -m pip install filetype erlpack`
 
 ## erlpack installation issue workaround
 
@@ -42,7 +42,7 @@ pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
 Mostly the same as the Debian-based Linux setup.
 
 - Install Python 3.9+
-- Install erlpack: `pip install filetype git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
+- Install erlpack: `pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
 - [Install mitmproxy](https://docs.mitmproxy.org/stable/overview-installation/#macos): `brew install mitmproxy`
 - Run mitmproxy at least once to generate its certificate: `mitmproxy`
 - [Install mitmproxy's certificate](https://docs.mitmproxy.org/stable/concepts-certificates/#quick-setup): `sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem`


### PR DESCRIPTION
This PR improves how the html exporter handles images.

- Prevent `OSError: [Errno 63] File name too long` by sanitizing file names derived from attachment ids
- Produce better filenames when using the `reasonable_filename` function
- Add the correct extension when discord converts image formats. This introduces a new dependency to the filetype library, I hope that is okay