### PR TITLE
HTML Exporter: add option to have exports named by channel id

### DIFF
--- a/html_exporter.py
+++ b/html_exporter.py
@@ -23,6 +23,7 @@ arg_parser = argparse.ArgumentParser(prog='python3 html_exporter.py')
 arg_parser.add_argument("-d","--dry",action='store_true', help="perform a dry run without actually writing any files")
 arg_parser.add_argument("-t","--traffic-archive", default="traffic_archive/", help="The traffic archive directory used for this conversion. Per default 'traffic_archive/'", metavar="<dir>")
 arg_parser.add_argument("-o","--output", default="html_exports/", help="The directory to export the output into. Per default 'html_exports/'", metavar="<dir>")
+arg_parser.add_argument('--channel-id-dirs', default=False, help="Name channel directory according to channel id", action='store_true')
 options = arg_parser.parse_args()
 
 DRY_RUN = options.dry
@@ -291,7 +292,10 @@ if not DRY_RUN:
         jenv = jinja2.Environment(loader=jinja2.FileSystemLoader('html_template'), autoescape=True)
         template = jenv.get_template("index.html")
 
-        chatlog_path = os.path.join(chatlogs_path, reasonable_filename(str(channel_id) + "-" + conversation_name))
+        if options.channel_id_dirs:
+            chatlog_path = os.path.join(chatlogs_path, f"channel_{channel_id}")
+        else:
+            chatlog_path = os.path.join(chatlogs_path, reasonable_filename(str(channel_id) + "-" + conversation_name))
         os.makedirs(chatlog_path)
         chatlog_attachments_path = os.path.join(chatlog_path, "attachments")
         os.mkdir(chatlog_attachments_path)

--- a/html_exporter.py
+++ b/html_exporter.py
@@ -23,7 +23,7 @@ arg_parser = argparse.ArgumentParser(prog='python3 html_exporter.py')
 arg_parser.add_argument("-d","--dry",action='store_true', help="perform a dry run without actually writing any files")
 arg_parser.add_argument("-t","--traffic-archive", default="traffic_archive/", help="The traffic archive directory used for this conversion. Per default 'traffic_archive/'", metavar="<dir>")
 arg_parser.add_argument("-o","--output", default="html_exports/", help="The directory to export the output into. Per default 'html_exports/'", metavar="<dir>")
-arg_parser.add_argument('--channel-id-dirs', default=False, help="Name channel directory according to channel id", action='store_true')
+arg_parser.add_argument('--channel-id-dirs', default=False, help="Name channel directories in the form channel_{channel id}", action='store_true')
 options = arg_parser.parse_args()
 
 DRY_RUN = options.dry


### PR DESCRIPTION
This is useful so that channels can have a more stable directory name that doesn't change with every export, meaning it is possible to link to a channel directory.