### PR TITLE
Zstd support

### DIFF
--- a/parse_gateway.py
+++ b/parse_gateway.py
@@ -112,7 +112,7 @@ def parse_gateway(gateway_path_prefix, url):
             elif query["encoding"] == "etf":
                 payload = deserialize_erlpackage(erlpack.unpack(payload))
             else:
-                assert 0, "Unrecognized querystring "+querystring+", did Discord upgrade its API version?"
+                assert 0, "Unrecognized encoding " + query["encoding"] + ", did Discord upgrade its API version?"
 
             yield payload
             

--- a/parse_gateway.py
+++ b/parse_gateway.py
@@ -8,9 +8,23 @@ todo: https://gateway-us-east1-d.discord.gg/?encoding=json&v=9&compress=zlib-str
 """
 
 import zlib
+import pyzstd
 import json
 import erlpack
 import urllib.parse
+
+"""
+Decodes the query part of a url and converts it to a dict
+"""
+def decode_querystring(querystring: str) -> dict[str, str]:
+    data = urllib.parse.parse_qs(querystring, keep_blank_values=True)
+    result = {}
+    for key, value in data.items():
+        if len(value) != 1:
+            print(f"query parameter '{key}' has been specified multiple times")
+            continue
+        result[key] = value[0]
+    return result
 
 """
 Recursively convert the bytes and Atom objects in a Gateway payload to strings.
@@ -34,9 +48,29 @@ def deserialize_erlpackage(payload):
 Yields deserialized Gateway payloads for a single archived Gateway connection.
 """
 def parse_gateway(gateway_path_prefix, url):
+    # parse query string for parameters
     querystring = urllib.parse.urlparse(url).query
-    decompressor = zlib.decompressobj()
+    query = decode_querystring(querystring)
+
+    # buffer to store the data
     buffer = bytearray()
+
+    # get compression scheme from query
+    if "compress" not in query:
+        print(f"discord websocket querystring doesn't contain a compression scheme: {querystring}")
+        return
+    compression_scheme = query["compress"]
+    is_zlib = compression_scheme == "zlib-stream"
+    is_zstd = compression_scheme == "zstd-stream"
+    decompressor = None
+    if is_zlib:
+        decompressor = zlib.decompressobj()
+    elif is_zstd:
+        decompressor = pyzstd.ZstdDecompressor()
+    if decompressor is None:
+        print(f"discord websocket traffic is encoded in an unsupported compression scheme: '{compression_scheme}'")
+        return
+
     with open(gateway_path_prefix + "_data", "rb") as data_file, open(gateway_path_prefix + "_timeline") as timeline_file:
         for line in timeline_file:
             try:
@@ -52,9 +86,11 @@ def parse_gateway(gateway_path_prefix, url):
             if not chunk:
                 print("Incomplete gateway.")
                 return
-            if not buffer.endswith(b'\x00\x00\xff\xff'):
+
+            # some form of zlib integrity checking
+            if is_zlib and not buffer.endswith(b'\x00\x00\xff\xff'):
                 continue
-            
+
             try:
                 payload = decompressor.decompress(buffer)
             except:
@@ -67,9 +103,13 @@ def parse_gateway(gateway_path_prefix, url):
             
             buffer = bytearray()
 
-            if querystring == "encoding=json&v=9&compress=zlib-stream":
+            if "encoding" not in query:
+                print(f"discord websocket querystring doesn't contain a encoding scheme: {querystring}")
+                return
+
+            if querystring in {"encoding=json&v=9&compress=zlib-stream","encoding=json&v=9&compress=zstd-stream"}:
                 payload = json.loads(payload.decode())
-            elif querystring == "encoding=etf&v=9&compress=zlib-stream":
+            elif querystring in {"encoding=etf&v=9&compress=zlib-stream","encoding=etf&v=9&compress=zstd-stream"}:
                 payload = deserialize_erlpackage(erlpack.unpack(payload))
             else:
                 assert 0, "Unrecognized querystring "+querystring+", did Discord upgrade its API version?"
@@ -84,7 +124,7 @@ if __name__ == "__main__":
             
             for i in parse_gateway("traffic_archive/gateways/" + gateway_name_prefix, url):
                 print("Payload of type {} and length {}.".format(i["t"], len(str(i))))
-            
+
 
 
 

--- a/parse_gateway.py
+++ b/parse_gateway.py
@@ -107,9 +107,9 @@ def parse_gateway(gateway_path_prefix, url):
                 print(f"discord websocket querystring doesn't contain a encoding scheme: {querystring}")
                 return
 
-            if querystring in {"encoding=json&v=9&compress=zlib-stream","encoding=json&v=9&compress=zstd-stream"}:
+            if query["encoding"] == "json":
                 payload = json.loads(payload.decode())
-            elif querystring in {"encoding=etf&v=9&compress=zlib-stream","encoding=etf&v=9&compress=zstd-stream"}:
+            elif query["encoding"] == "etf":
                 payload = deserialize_erlpackage(erlpack.unpack(payload))
             else:
                 assert 0, "Unrecognized querystring "+querystring+", did Discord upgrade its API version?"

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Here are example commands you can use on Ubuntu. Assumes you use Python 3.9, but
 - Update pip: `python3.9 -m pip install --upgrade pip`
 - Install mitmproxy: download the binaries from [mitmproxy.org](https://mitmproxy.org/)
 - [Install mitmproxy's certificate](https://docs.mitmproxy.org/stable/concepts-certificates/#quick-setup) on every device with a Discord client that you want to archive with. (Sometimes you also have to install it on the browser level.)
-- Install filetype and erlpack: `python3.9 -m pip install filetype erlpack`
+- Install pyzstd, filetype and erlpack: `python3.9 -m pip install pyzstd filetype erlpack`
 
 ## erlpack installation issue workaround
 
@@ -62,11 +62,11 @@ git clone https://github.com/Roachbones/discordless
 cd discordless
 ```
 
-Update pip and install `erlpack` and `python-dateutil` dependencies:
+Update pip and install `pyzstd`, `erlpack` and `python-dateutil` dependencies:
 ```
 py -m pip install --upgrade pip
 py -m pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack
-py -m pip install python-dateutil filetype
+py -m pip install python-dateutil filetype pyzstd
 ```
 
 Install mitmproxy from [official site](https://mitmproxy.org/). Mitmproxy installer for windows should automatically add `mitmproxy`, `mitmdump` and `mitmweb` to path. Close all opened command prompts to update PATH variable.

--- a/wumpus_in_the_middle.py
+++ b/wumpus_in_the_middle.py
@@ -127,19 +127,9 @@ class DiscordArchiver:
         self.gatekeepers = {}
 
     def websocket_message(self, flow: http.HTTPFlow):
-        if flow.request.pretty_url not in (
-            "https://gateway.discord.gg/?encoding=etf&v=9&compress=zlib-stream",
-            "https://gateway.discord.gg/?encoding=json&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-a.discord.gg/?encoding=etf&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-a.discord.gg/?encoding=json&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-b.discord.gg/?encoding=etf&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-b.discord.gg/?encoding=json&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-c.discord.gg/?encoding=etf&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-c.discord.gg/?encoding=json&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-d.discord.gg/?encoding=etf&v=9&compress=zlib-stream",
-            "https://gateway-us-east1-d.discord.gg/?encoding=json&v=9&compress=zlib-stream"
-        ):
-            log_info("Unrecognized websocket url: " + flow.request.pretty_url)
+        # aggressively capture any potential discord traffic
+        if "discord" not in flow.request.pretty_url:
+            log_info("Non-discord websocket url: " + flow.request.pretty_url)
             return
         message = flow.websocket.messages[-1]
         if message.from_client:

--- a/wumpus_in_the_middle.py
+++ b/wumpus_in_the_middle.py
@@ -73,6 +73,9 @@ def url_has_discord_root_domain(url):
         any(hostname.endswith(domain) for domain in DISCORD_DOMAINS)
     )
 
+def url_is_gateway(url):
+    return url_has_discord_root_domain(url) and "gateway" in url
+
 """
 Lossily turn a string into a reasonable/safe filename, possibly truncating it.
 Uses a max filename length of 255.
@@ -128,8 +131,8 @@ class DiscordArchiver:
 
     def websocket_message(self, flow: http.HTTPFlow):
         # aggressively capture any potential discord traffic
-        if "discord" not in flow.request.pretty_url:
-            log_info("Non-discord websocket url: " + flow.request.pretty_url)
+        if not url_is_gateway(flow.request.pretty_url):
+            log_info("websocket message is from non-gateway traffic: " + flow.request.pretty_url)
             return
         message = flow.websocket.messages[-1]
         if message.from_client:


### PR DESCRIPTION
Since a while, discord has been using zstd for compressing their websocket traffic (https://discord.com/blog/how-discord-reduced-websocket-traffic-by-40-percent). Discordless currently can't handle this (https://github.com/Roachbones/discordless/issues/21). This PR adds support for decoding zstd encoded traffic to discordless.

Python doesn't support zstd out of the box, it needs a dependency for this. However, support for zstd might eventually come: https://peps.python.org/pep-0784/. Due to this, I've chosen to use the library that will probably end up being the python standard library implementation.

Additionally, I've changed wumpus_in_the_middle to capture any websocket traffic, not just a selected few endpoints. The current filter is restrictive enough that it didn't continue recording websocket traffic after the compression scheme changed, meaning my archives have a multi-month gap.