### PR TITLE
mitmdump: always select first valid gateway id

### DIFF
--- a/wumpus_in_the_middle.py
+++ b/wumpus_in_the_middle.py
@@ -123,7 +123,7 @@ class DiscordArchiver:
             _timestamp, _method, url, response_hash, _filename = line.rstrip().split(maxsplit=4)
             self.recorded_response_hashes.add((url, response_hash))
 
-        self.recorded_gateways_count = max(int(line.split(" ")[-1]) for line in self.gateway_index_file)+1 # find first unused gateway id
+        self.recorded_gateways_count = max((int(line.split(" ")[-1])+1 for line in self.gateway_index_file),default=0) # find first unused gateway id
         self.gatekeepers = {}
 
         log_info(f"first unused gateway flow id is {self.recorded_gateways_count}")

--- a/wumpus_in_the_middle.py
+++ b/wumpus_in_the_middle.py
@@ -123,8 +123,10 @@ class DiscordArchiver:
             _timestamp, _method, url, response_hash, _filename = line.rstrip().split(maxsplit=4)
             self.recorded_response_hashes.add((url, response_hash))
 
-        self.recorded_gateways_count = sum(1 for line in self.gateway_index_file)
+        self.recorded_gateways_count = max(int(line.split(" ")[-1]) for line in self.gateway_index_file)+1 # find first unused gateway id
         self.gatekeepers = {}
+
+        log_info(f"first unused gateway flow id is {self.recorded_gateways_count}")
 
     def websocket_message(self, flow: http.HTTPFlow):
         if flow.request.pretty_url not in (


### PR DESCRIPTION
As long as (PR https://github.com/Roachbones/discordless/pull/23 disable buffering for gateway recording) isn't merged, the gateway index can corrupt and the first free gateway recording id does not necessarily correspond with the number of gateway_index entries. 

This PR fixes it by scanning the gateway index for the first guaranteed free number based on the contents of the index file.

Unless someone notices something, I'll merge this in 1-2 days.