### PR TITLE
remove erlpack workaround

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,20 +29,11 @@ Here are example commands you can use on Ubuntu. Assumes you use Python 3.9, but
 - [Install mitmproxy's certificate](https://docs.mitmproxy.org/stable/concepts-certificates/#quick-setup) on every device with a Discord client that you want to archive with. (Sometimes you also have to install it on the browser level.)
 - Install pyzstd, filetype and erlpack: `python3.9 -m pip install pyzstd filetype erlpack`
 
-## erlpack installation issue workaround
-
-**Not sure if this is still the case; try this if you get an error when trying to install erlpack.**
-
-Discord uses a tool called erlpack to deserialize objects sent over the Gateway websocket, but it's currently(?) broken. There's a pull request open for oliver-ni's branch, which fixes the problem, but Discord hasn't merged it. So, just install Oliver's version: 
-```
-pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
-```
-
 # Install and setup - Mac
 Mostly the same as the Debian-based Linux setup.
 
 - Install Python 3.9+
-- Install erlpack: `pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack`
+- Install erlpack: `pip install pyzstd filetype erlpack python-dateutilf`
 - [Install mitmproxy](https://docs.mitmproxy.org/stable/overview-installation/#macos): `brew install mitmproxy`
 - Run mitmproxy at least once to generate its certificate: `mitmproxy`
 - [Install mitmproxy's certificate](https://docs.mitmproxy.org/stable/concepts-certificates/#quick-setup): `sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem`
@@ -65,8 +56,7 @@ cd discordless
 Update pip and install `pyzstd`, `erlpack` and `python-dateutil` dependencies:
 ```
 py -m pip install --upgrade pip
-py -m pip install git+https://github.com/oliver-ni/erlpack.git#egg=erlpack
-py -m pip install python-dateutil filetype pyzstd
+py -m pip install python-dateutil filetype pyzstd erlpack
 ```
 
 Install mitmproxy from [official site](https://mitmproxy.org/). Mitmproxy installer for windows should automatically add `mitmproxy`, `mitmdump` and `mitmweb` to path. Close all opened command prompts to update PATH variable.


### PR DESCRIPTION
It seems to be working when installing the normal erlpack library. Tested on python 3.13.